### PR TITLE
Harmonize de_DE locale with the ojs locale

### DIFF
--- a/locale/de_DE/locale.xml
+++ b/locale/de_DE/locale.xml
@@ -18,7 +18,7 @@
 	<message key="plugins.generic.googleAnalytics.description"><![CDATA[Verbinden Sie OJS mit Google Analytics, der Google-Anwendung zur Nutzungsanalyse von Webseiten-Traffic. Voraussetzung ist, dass Sie bereits einen Google-Analytics-Zugang haben. Siehe <a href="http://www.google.com/analytics/" title="Google Analytics site">Google Analytics</a> für weitere Informationen.]]></message>
 
 	<!-- Google Analytics Settings Management -->
-	<message key="plugins.generic.googleAnalytics.manager.settings.description"><![CDATA[<p>Mit diesem Plug-In ist es möglich, Nutzung und Traffic für diese Zeitschrift zu erheben und zu analysieren. Bitte beachten Sie, dass Sie hierfür bereits einen Google-Analytics-Zugang haben müssen. Siehe <a href="http://www.google.com/analytics/" title="Google Analytics site">Google Analytics</a> für weitere Informationen.</p>]]></message>
+	<message key="plugins.generic.googleAnalytics.manager.settings.description"><![CDATA[<p>Mit diesem Plugin ist es möglich, Nutzung und Traffic für diese Zeitschrift zu erheben und zu analysieren. Bitte beachten Sie, dass Sie hierfür bereits einen Google-Analytics-Zugang haben müssen. Siehe <a href="http://www.google.com/analytics/" title="Google Analytics site">Google Analytics</a> für weitere Informationen.</p>]]></message>
 	<message key="plugins.generic.googleAnalytics.manager.settings.googleAnalyticsSiteId">Account-ID</message>
 	<message key="plugins.generic.googleAnalytics.manager.settings.googleAnalyticsSiteIdRequired">Bitte geben Sie die Account-ID ein.</message>
 	<message key="plugins.generic.googleAnalytics.authorAccount">Google Analytics Account-Nummer</message>


### PR DESCRIPTION
The [main locale](https://github.com/pkp/ojs/blob/master/locale/de_DE/locale.xml) of ojs translates `plugin` as `Plugin` not as `Plug-In`.