### PR TITLE
Update analytics script based on newest GA4 script

### DIFF
--- a/GoogleAnalyticsPlugin.inc.php
+++ b/GoogleAnalyticsPlugin.inc.php
@@ -132,13 +132,11 @@ class GoogleAnalyticsPlugin extends GenericPlugin
         }
 
         $googleAnalyticsCode = "
-(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-
-ga('create', '${googleAnalyticsSiteId}', 'auto');
-ga('send', 'pageview');
+(function (w, d, s, l, i) { w[l] = w[l] || []; var f = d.getElementsByTagName(s)[0],
+j = d.createElement(s), dl = l != 'dataLayer' ? '&l=' + l : ''; j.async = true; 
+j.src = 'https://www.googletagmanager.com/gtag/js?id=' + i + dl; f.parentNode.insertBefore(j, f); 
+function gtag(){dataLayer.push(arguments)}; gtag('js', new Date()); gtag('config', i); })
+(window, document, 'script', 'dataLayer', '$googleAnalyticsSiteId');";
 ";
 
         $templateMgr = TemplateManager::getManager($request);


### PR DESCRIPTION
Add support for new google analytics GA4

Google is now pushing analytics v4 in this article
https://support.google.com/analytics/answer/11583528

Change are made to backward compability and detect property id version change are made based on
https://support.google.com/analytics/answer/11583832
https://support.google.com/analytics/answer/9310895